### PR TITLE
send user to /wp-admin/admin.php instead of wp-admin. It wont trigger…

### DIFF
--- a/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
@@ -364,7 +364,6 @@ class Verify extends ImportCsvAttendeesStep
                 array(
                     'page' => 'espresso_batch',
                     'batch' => 'job',
-                    'label' => esc_html__('Applying Offset', 'event_espresso'),
                     'job_handler' => urlencode(get_class($this->attendeesUiManager->getBatchJobHandler())),
                     'return_url' => urlencode(
                         add_query_arg(
@@ -379,8 +378,7 @@ class Verify extends ImportCsvAttendeesStep
                             )
                         )
                     ),
-                ),
-                admin_url()
+                )
             )
         );
 


### PR DESCRIPTION


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes a redirect happening on MENW (see https://github.com/eventespresso/eea-importer/issues/55) because the URL we were using was triggering the whitelabeller add-on's redirect behaviour.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] On MENW (or a local copy) use the importer. You should not get redirected to the event list

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
