### PR TITLE
unhook the WP Users integration filter callback during import

### DIFF
--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -52,6 +52,14 @@ class ImportCommandHandler extends CompositeCommandHandler
         );
         remove_all_filters('AHEE__EE_Payment_Processor__update_txn_based_on_payment__successful');
 
+        // WP User Add-on: please don't try to sync imported users to the current user
+        if(method_exists('EED_WP_Users_SPCO','maybe_sync_existing_attendee')) {
+            remove_filter(
+                'FHEE_EE_Single_Page_Checkout__save_registration_items__find_existing_attendee',
+                ['EED_WP_Users_SPCO','maybe_sync_existing_attendee']
+            );
+        }
+
         $transaction = $attendee = $this->commandBus()->execute(
             $this->commandFactory()->getNew(
                 'EventEspresso\AttendeeImporter\domain\services\commands\ImportTransactionCommand',

--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -53,7 +53,7 @@ class ImportCommandHandler extends CompositeCommandHandler
         remove_all_filters('AHEE__EE_Payment_Processor__update_txn_based_on_payment__successful');
 
         // WP User Add-on: please don't try to sync imported users to the current user
-        if(method_exists('EED_WP_Users_SPCO','maybe_sync_existing_attendee')) {
+        if (method_exists('EED_WP_Users_SPCO', 'maybe_sync_existing_attendee')) {
             remove_filter(
                 'FHEE_EE_Single_Page_Checkout__save_registration_items__find_existing_attendee',
                 ['EED_WP_Users_SPCO','maybe_sync_existing_attendee']


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
When importing attendees and the WP User integration add-on was active, the WP user integration add-on would replace the imported user with the user associated with the current user (which is the desired behaviour in SPCO, but not when importing). This work prevents that by unhooking the WP user integration filter callback during imports.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Activate the WP user integration add-on. Import from the sample CSV. On master branch of the importer, you'd actually see the same CSV row imported TWICE, whereas with this branch they're imported as normal.
* [ ] Verify there is no regression in the WP user integration add-on when the importer is active. ie, when you register through SPCO, and are logged in, the EE attendee associated with your user should get updated.


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
