### PR TITLE
slow it down cause its resource intensive, especially with Keap (Infusionsoft)

### DIFF
--- a/src/domain/services/batch/JobHandlers/AttendeeImporterBatchJob.php
+++ b/src/domain/services/batch/JobHandlers/AttendeeImporterBatchJob.php
@@ -130,7 +130,8 @@ class AttendeeImporterBatchJob extends JobHandler
         $batch_size = max($batch_size, 1);
         while ($processed_this_batch < $batch_size) {
             $csv_row = $this->manager->getExtractor()->getItemAt(
-                $job_parameters->units_processed() + 1 + $processed_this_batch);
+                $job_parameters->units_processed() + 1 + $processed_this_batch
+            );
             if (! $csv_row) {
                 break;
             }

--- a/src/domain/services/batch/JobHandlers/AttendeeImporterBatchJob.php
+++ b/src/domain/services/batch/JobHandlers/AttendeeImporterBatchJob.php
@@ -2,7 +2,7 @@
 
 namespace EventEspresso\AttendeeImporter\domain\services\batch\JobHandlers;
 
-use Dompdf\Exception;
+use Exception;
 use EE_Error;
 // Import Infusionsoft. We'll check the add-on is active before trying to use it.
 use EED_Infusionsoft;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Imports fewer rows per batch step (ajax request), as the default of 50 records per request was taking like 10 seconds locally, which is a little long. By default, if `EE_BATCH_STEP_SIZE` is 50, the default, will instead only migrate 25 CSV rows per request (half); if Keap is active, will instead do 7 CSV rows per request (an eighth). This will help prevent timeouts during imports.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Do a migration with this larger file [tons-of-attendees-with-custom-questions.zip](https://github.com/eventespresso/eea-importer/files/3315402/tons-of-attendees-with-custom-questions.zip), and verify requests don't time out
* [x] Activate Keap/Infusionsoft, and do another import. It should go slower, but again each request should be under 10 seconds in order to avoid timeouts (30 seconds is the absolute limit, but we want to account for slower servers)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
