### PR TITLE
on ES, the constant EE_INFUSIONSOFT_VERSIoN gets defined but the clas…

### DIFF
--- a/src/domain/services/batch/JobHandlers/AttendeeImporterBatchJob.php
+++ b/src/domain/services/batch/JobHandlers/AttendeeImporterBatchJob.php
@@ -119,7 +119,8 @@ class AttendeeImporterBatchJob extends JobHandler
 
         // Importing with Infusionsoft is more expensive yet, so let's slow it down some more.
         try {
-            if (defined('EE_INFUSIONSOFT_VERSION') && EED_Infusionsoft::infusionsoft_connection()) {
+            if (class_exists('EED_Infusionsoft')
+                && EED_Infusionsoft::infusionsoft_connection()) {
                 $batch_size /= 4;
             }
         } catch (Exception $e) {


### PR DESCRIPTION
…s EED_Infusionsoft may not be


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes a fatal error running the importer introduced on https://github.com/eventespresso/eea-importer/pull/63.
On my local copy of EventSmart, I upgraded to the latest importer add-on and EE core, and got a fatal error because while Infusionsoft is active (so its version constant is defined), it may not be *loaded* so its class `EED_Infusionsoft` isn't defined.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Run the importer locally with Infusionsoft not activated
* [x] Run the importer locally with Infusionsoft activated
* [ ] On a local copy of Eventsmart (or after merging this into master, and updating all the plugins on MENW) run the importer without paying for the infusionsoft feature. It should work fine.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
