### PR TITLE
make sure the registration we get from the command matches whats in t…

### DIFF
--- a/src/EE_Importer.class.php
+++ b/src/EE_Importer.class.php
@@ -183,6 +183,7 @@ class EE_Importer extends EE_Addon
                 'EE_Registration_Processor' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\commands\CommandBusInterface'     => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\commands\CommandFactoryInterface' => EE_Dependency_Map::load_from_cache,
+                'EEM_Registration' => EE_Dependency_Map::load_from_cache
             ],
             'EventEspresso\AttendeeImporter\domain\services\commands\ImportAnswersCommandHandler' => [
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,

--- a/src/domain/services/commands/ImportRegistrationCommandHandler.php
+++ b/src/domain/services/commands/ImportRegistrationCommandHandler.php
@@ -5,6 +5,7 @@ namespace EventEspresso\AttendeeImporter\domain\services\commands;
 use EE_Attendee;
 use EE_Error;
 use EE_Registration_Processor;
+use EEM_Registration;
 use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -32,13 +33,20 @@ class ImportRegistrationCommandHandler extends CompositeCommandHandler
      */
     private $registration_processor;
 
+    /**
+     * @var EEM_Registration
+     */
+    private $registration_model;
+
     public function __construct(
         EE_Registration_Processor $registration_processor,
         CommandBusInterface $command_bus,
-        CommandFactoryInterface $command_factory
+        CommandFactoryInterface $command_factory,
+        EEM_Registration $registration_model
     ) {
         parent::__construct($command_bus, $command_factory);
         $this->registration_processor = $registration_processor;
+        $this->registration_model = $registration_model;
     }
 
 
@@ -69,6 +77,11 @@ class ImportRegistrationCommandHandler extends CompositeCommandHandler
                 ]
             )
         );
+
+        // Make sure we're using the registration from the entity map. If other code hooked into
+        // `AHEE__EEM_Base__insert__end`, and then fetched the object, a different registration is in the entity map
+        // than this one, which often creates problems later, so make sure we're using what's in the entity map.
+        $registration = $this->registration_model->refresh_entity_map_from_db($registration->ID());
 
         // update registration based on other related details
         $this->registration_processor->toggle_incomplete_registration_status_to_default(


### PR DESCRIPTION
…he model entity map


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
On EventSmart (and probably while using Infusionsoft) if you import an attendee with a payment, the registration gets saved without an ATT_ID. That's because if an add-on hooks into `AHEE__EEM_Base__insert__end`, and then fetches the model object from the ID, the model's entity map will end up with a different model object than the code that called `save` on the model object (so there is one in the entity map, and the other isn't). Later on when we set the `ATT_ID` on the registration that's not in the entity map, and go to save it, it works BUT the other registration in the entity map can get saved, and overwrite it.

(Note: Other code should probably hook in AFTER the model object has been saved to the entity map, rather than before it; we could make another ticket to do that.)

This resolves the problem by, immediately after saving the registration, replacing it with what's in the entity map (if they're the same, no problem too). This way we avoid having two model object floating around representing the same database row.

see https://github.com/eventespresso/eventsmart.com-website/issues/470#issuecomment-505947919

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] With no other add-ons active, do an import using the payment row. It should work fine.
* [ ] Repeat the above but with the Infusionsoft add-on active. The result should be the same.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
