### PR TITLE
save the registration after weve updated it

### DIFF
--- a/src/domain/services/commands/ImportRegistrationPaymentCommandHandler.php
+++ b/src/domain/services/commands/ImportRegistrationPaymentCommandHandler.php
@@ -76,7 +76,7 @@ class ImportRegistrationPaymentCommandHandler extends CompositeCommandHandler
 
         $this->registration_processor->toggle_registration_status_if_no_monies_owing(
             $command->getRegistration(),
-            false,
+            true,
             [
                 'payment_updates' => $command->getPayment() instanceof EE_Payment,
                 'last_payment' => $command->getPayment(),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes imported payments always being "pending payment" even when fully paid.
This was a bug because we switched to updating the payment status later during the request, and now need to resave the registration.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Create an event with a $10 ticket. Import attendees to it from the sample CSV. One should be approved, the other pending payment.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
