### PR TITLE
Enh/add action to import

### DIFF
--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -144,6 +144,8 @@ class ImportCommandHandler extends CompositeCommandHandler
             )
         );
 
+        do_action('AHEE__EventEspresso_AttendeeImporter_domain_services_commands_ImportCommandHandler__handle__end', $this, $command, $registration, $transaction, $attendee );
+
         return null;
     }
 }

--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -60,7 +60,7 @@ class ImportCommandHandler extends CompositeCommandHandler
             );
         }
 
-        $transaction = $attendee = $this->commandBus()->execute(
+        $transaction = $this->commandBus()->execute(
             $this->commandFactory()->getNew(
                 'EventEspresso\AttendeeImporter\domain\services\commands\ImportTransactionCommand',
                 [
@@ -107,7 +107,7 @@ class ImportCommandHandler extends CompositeCommandHandler
             )
         );
 
-        $this->commandBus()->execute(
+        $attendee = $this->commandBus()->execute(
             $this->commandFactory()->getNew(
                 'EventEspresso\AttendeeImporter\domain\services\commands\ImportAttendeeCommand',
                 [


### PR DESCRIPTION
Howdy Brent,

Not really sure if this is the correct way to do this, iirc commands weren't intended to include hooks like this but I couldn't see any other way to hook in and perform additional command/actions.

## Problem this Pull Request solves
Allows users (or another add-on) to hook into the import function and do whatever they need to do.

The use case I did this for was to allow users to be created when importing registrations (See [HERE](https://eventespresso.com/topic/create-user-account-on-import-2/)), right now the only way I could find to do that was to hack into the import `ImportCommandHandler` but if there's another way I'm missing can you let me know, please?

## How has this been tested
I used the snippet here to test the hook worked:

https://gist.github.com/Pebblo/31af4a4c4b291c0a60191a5e7edad6bb

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
