### PR TITLE
Set all reg core reg steps as complete within imported transactions.

### DIFF
--- a/src/domain/services/commands/ImportTransactionCommandHandler.php
+++ b/src/domain/services/commands/ImportTransactionCommandHandler.php
@@ -42,6 +42,14 @@ class ImportTransactionCommandHandler extends CompositeCommandHandler
             )
         );
         // Mark the transaction as complete eh.
+        $transaction->set_reg_steps(
+            array(
+                'attendee_information'  => true,
+                'payment_options'       => true,
+                'finalize_registration' => current_time( 'timestamp' ),
+            )
+        );
+        // Save the transaction to the DB.
         $transaction->save();
         return $transaction;
     }


### PR DESCRIPTION
Imported registrations don't have any reg steps set on them at all, this causes problems when you try to 'revisit' a registration to pay so these changes just set all of the 'core' reg steps to be complete on imports.

On master, import a registration on an event and try to view the payment options step using a revisit link (the payment reminder or receipt has one).
You'll see the attendee information step.

In this branch you should see the payment options.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
