### PR TITLE
Skip mapping for the 'email_confirm' system question.

### DIFF
--- a/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
+++ b/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
@@ -108,6 +108,7 @@ class MapCsvColumnsSubform extends EE_Form_Section_Proper
             foreach ($question_group->questions() as $question) {
                 if ($question->is_system_question()) {
                     if ($question->system_ID() === 'email_confirm') {
+                        // Skip mapping the 'Confirm Email Address' system question.
                         continue;
                     } elseif ($question->system_ID() === 'state') {
                         $append = 'STA_ID';

--- a/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
+++ b/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
@@ -107,7 +107,9 @@ class MapCsvColumnsSubform extends EE_Form_Section_Proper
         foreach ($question_groups_for_event as $question_group) {
             foreach ($question_group->questions() as $question) {
                 if ($question->is_system_question()) {
-                    if ($question->system_ID() === 'state') {
+                    if ($question->system_ID() === 'email_confirm') {
+                        continue;
+                    } elseif ($question->system_ID() === 'state') {
                         $append = 'STA_ID';
                     } elseif ($question->system_ID() === 'country') {
                         $append = 'CNT_ISO';


### PR DESCRIPTION
This issue was reported by one of our users.

If you have the 'Confirm Email Address' system question set on the event you are importing into the CSV Map step will show that question to be mapped.

If you try to map a field to that question you'll get a fatal error, if the user simply ignores that field when mapping their values the import works as expected.

Here's a stack trace for the fatal:

```
[09-Nov-2021 14:28:47 UTC] PHP Fatal error:  Uncaught Error: Call to a member function map() on null in C:\laragon\www\ee4\wp-content\plugins\eea-importer\src\application\services\import\config\models\ImportModelConfigBase.php:124
Stack trace:
#0 C:\laragon\www\ee4\wp-content\plugins\eea-importer\src\domain\services\import\csv\attendees\forms\form_handlers\MapCsvColumns.php(116): EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigBase->map('Address Part 1', 'ATT_email_confi...')
#1 C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\core\libraries\form_sections\form_handlers\SequentialStepFormManager.php(555): EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\MapCsvColumns->process(Array)
#2 C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\core\libraries\form_sections\form_handlers\SequentialStepFormManager.php(413): EventEspresso\core\libraries\form_sections\form_handlers\SequentialStepFormManager->processCurrentStepForm(Array)
#3 C:\laragon\www\ee4\wp-c in C:\laragon\www\ee4\wp-content\plugins\eea-importer\src\application\services\import\config\models\ImportModelConfigBase.php on line 124
```

## Problem this Pull Request solves
This PR simply skips adding that Confirm email address (only the system question version incase someone has added their own somewhere) to prevent that fatal.


## How has this been tested
Add the 'Confirm Email Address' question to Personal Info in  Event Espresso -> Registration Form -> Question Groups -> Personal Info.

Export the registrations for **one** of your Events (not all registrations) so you have a CSV to import.

Go to Event Espresso -> Importer.

Select an event, select a ticket (if needed), then select your registration CSV from above to import.

In the dropdown for your mapped question fields, make sure the 'Confirm Email Address' field is NOT shown.

Map your First Name, Last Name and Email address questions correctly and import, make sure the import works without throwing an error.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
